### PR TITLE
fix: fix dotnet workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Add BepInEx nuget source
-      run: dotnet nuget add source https://nuget.bepinex.dev/v3/index.json -n nuget.bepinex.dev #
+      run: dotnet nuget add source https://nuget.bepinex.dev/v3/index.json -n nuget.bepinex.dev
     - name: Add BepInEx packages
       run: | # adds https://nuget.bepinex.dev/packages/BepInEx.IL2CPP and https://nuget.bepinex.dev/packages/BepInEx.PluginInfoProps
         dotnet add package BepInEx.IL2CPP --version 6.0.0-pre.1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,6 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
+  
 name: .NET
 
 on:
@@ -20,6 +20,12 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+    - name: Add BepInEx nuget source
+      run: dotnet nuget add source https://nuget.bepinex.dev/v3/index.json -n nuget.bepinex.dev #
+    - name: Add BepInEx packages
+      run: | # adds https://nuget.bepinex.dev/packages/BepInEx.IL2CPP and https://nuget.bepinex.dev/packages/BepInEx.PluginInfoProps
+        dotnet add package BepInEx.IL2CPP --version 6.0.0-pre.1
+        dotnet add package BepInEx.PluginInfoProps --version 2.1.0
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
NOTE: doesn't fully fix workflow builds yet, most dependencies grabbed from the local Fall Guys Steam install are missing on the CI server.

Fixes the unable to find package error as seen in [#1](https://github.com/kota69th/CreativeExpansionPack/actions/runs/5847378668/job/15853575231), making the workflow progress to the next error.

Edit 1: Also adds the workflow_dispatch event to make repository owners able to manually trigger CI build.

Edit 2: Example run: [ItsNiceCraft/CreativeExpansionPack run #1](https://github.com/ItsNiceCraft/CreativeExpansionPack/actions/runs/5890412209/job/15975452041)